### PR TITLE
refactor(ci): rename workflow jobs for better clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     tags: [ 'v*' ]
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
     
     steps:
@@ -29,8 +29,8 @@ jobs:
     - name: Test
       run: dotnet test BlazorTS.SourceGenerator.Tests/ -c Release --no-build
 
-  pack-and-publish:
-    needs: build-and-test
+  package:
+    needs: test
     runs-on: ubuntu-latest
     
     steps:
@@ -66,8 +66,8 @@ jobs:
         name: nuget-packages
         path: artifacts/*.nupkg
 
-  package-test:
-    needs: pack-and-publish
+  integration-test:
+    needs: package
     runs-on: ubuntu-latest
     
     steps:
@@ -109,8 +109,8 @@ jobs:
       run: dotnet test BlazorTS.TestPackage/ -c Release
       shell: bash
 
-  publish:
-    needs: package-test
+  release:
+    needs: integration-test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
     

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ export function greet(name: string, age?: number): void {
 }
 ```
 
-### 2. 项目配置
+### 2. 安装包
+```bash
+# 安装BlazorTS源代码生成器
+dotnet add package BlazorTS
+dotnet add package BlazorTS.SourceGenerator
+```
+
 ```xml
-<!-- 项目文件中添加 -->
+<!-- 在项目文件中添加TypeScript文件为附加文件 -->
 <ItemGroup>
-  <PackageReference Include="BlazorTS.SourceGenerator" Version="0.1.0-dev" />
   <AdditionalFiles Include="**/*.ts" />
 </ItemGroup>
 ```


### PR DESCRIPTION
Rename CI workflow jobs to be more descriptive:
- build-and-test → test
- pack-and-publish → package
- package-test → integration-test
- publish → release

Also update job dependencies to match new naming convention.