### PR TITLE
Add DLL resolver for TypeScript parser native libraries

### DIFF
--- a/BlazorTS.SourceGenerator.Tests/ResolveGeneratorTests.cs
+++ b/BlazorTS.SourceGenerator.Tests/ResolveGeneratorTests.cs
@@ -143,4 +143,5 @@ function processData(
         Assert.Contains("await invoker.InvokeAsync<object?>", wrapperCode);
         Assert.DoesNotContain("Task<void>", wrapperCode);
     }
+
 }

--- a/BlazorTS.SourceGenerator/DllResolver.cs
+++ b/BlazorTS.SourceGenerator/DllResolver.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace BlazorTS.SourceGenerator
+{
+    /// <summary>
+    /// DLL解析器类 - 管理Native库路径和解析
+    /// </summary>
+    public class DllResolver
+    {
+        private readonly string? _nativePath;
+
+        /// <summary>
+        /// 构造函数，接收native路径
+        /// </summary>
+        public DllResolver(string? nativePath = null)
+        {
+            _nativePath = nativePath;
+        }
+
+        /// <summary>
+        /// DLL导入解析器
+        /// </summary>
+        public IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            if (!string.IsNullOrEmpty(_nativePath) && _nativePath != "未找到")
+            {
+                // 构建可能的库文件路径
+                var possiblePaths = new[]
+                {
+                    Path.Combine(_nativePath, $"lib{libraryName}.so"),
+                    Path.Combine(_nativePath, $"{libraryName}.so"),
+                    Path.Combine(_nativePath, $"{libraryName}.dll")
+                };
+
+                foreach (var path in possiblePaths)
+                {
+                    try
+                    {
+                        return NativeLibrary.Load(path);
+                    }
+                    catch
+                    {
+                        // 忽略加载失败，继续尝试下一个路径
+                    }
+                }
+            }
+            // 回退到默认行为
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/BlazorTS.TestPackage/SourceGeneratorTest.cs
+++ b/BlazorTS.TestPackage/SourceGeneratorTest.cs
@@ -1,19 +1,16 @@
 using System.Reflection;
 using Xunit;
 
-namespace BlazorTS.TestPackage.Tests
+namespace BlazorTS.TestPackage
 {
-
     public partial class TestFunctions { }
-
     public class SourceGeneratorTests
     {
         [Fact]
         public void Test_Generated_Functions_Exist()
         {
-
-            // 使用反射测试确保正确生成函数
-            var testFunctionsType = typeof(BlazorTS.TestPackage.TestFunctions);
+            // 使用反射测试确保正确生成函数 - 引用实际的生成类
+            var testFunctionsType = typeof(TestFunctions);
             
             // 获取TSInterop嵌套类
             var tsInteropType = testFunctionsType.GetNestedType("TSInterop");
@@ -28,5 +25,4 @@ namespace BlazorTS.TestPackage.Tests
             Assert.Contains("greet", methodNames);
         }
     }
-
 }

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ public partial class TestFunctions
 ```bash
 dotnet clean
 dotnet nuget locals all --clear
-
 rm -rf **/bin **/obj
 rm -rf ./artifacts
 
 # or trash
+dotnet clean
+dotnet nuget locals all --clear
 trash -f **/bin **/obj
 trash -f ./artifacts/*.nupkg
 ```
@@ -134,7 +135,9 @@ dotnet test
 ### 打包测试
 ```bash
 dotnet pack --configuration Release --output ./artifacts/
-dotnet test BlazorTS.TestPackage/
+dotnet build-server shutdown
+dotnet add package  BlazorTS.SourceGenerator --version 0.1.0-dev --project BlazorTS.TestPackage/
+BLAZORTS_LOG_ENABLED=true dotnet test BlazorTS.TestPackage/
 ```
 
 ## CI/CD流程


### PR DESCRIPTION
- Add DllResolver.cs to handle native library resolution
- Update Helper.cs to get native path from build properties or assembly metadata
- Modify test configuration to include TypeScriptParserNativePath
- Add assembly metadata extraction in TestBase for native path resolution